### PR TITLE
Fix session deletion status

### DIFF
--- a/frontendshared/src/commonMain/kotlin/de/lehrbaum/initiativetracker/networking/BackendNetworkClient.kt
+++ b/frontendshared/src/commonMain/kotlin/de/lehrbaum/initiativetracker/networking/BackendNetworkClient.kt
@@ -37,16 +37,17 @@ class BackendNetworkClient(private val httpClient: HttpClient) {
 		}
 	}
 
-	suspend fun deleteSession(combatLink: CombatLink): Result<Unit> {
-		return runCatching {
-			withContext(Dispatchers.IO) {
-				Napier.v("Attempting to delete Session $combatLink")
-		val response = httpClient.delete {
-			val path = combatLink.sessionId?.let { "$SESSION_PATH/$it" } ?: SESSION_PATH
-			backendHttpUrl(combatLink.backendUri, path)
-		}
-		Napier.i("Response for delete Session: $response")
-			}
-		}
-	}
+        suspend fun deleteSession(combatLink: CombatLink): Result<Unit> {
+                return runCatchingNested {
+                        withContext(Dispatchers.IO) {
+                                Napier.v("Attempting to delete Session $combatLink")
+                                val response = httpClient.delete {
+                                        val path = combatLink.sessionId?.let { "$SESSION_PATH/$it" } ?: SESSION_PATH
+                                        backendHttpUrl(combatLink.backendUri, path)
+                                }
+                                Napier.i("Response for delete Session: $response")
+                                response.bodyOrFailure()
+                        }
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- check server HTTP response when deleting a session

## Testing
- `./gradlew :backendjvm:compileKotlin --no-daemon`
- `./gradlew :backendshared:jvmTest --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6884aa2a9b4883329689d0d5e0d3b2ab