### PR TITLE
Fix typo in OpenAiNetworkClient prompt

### DIFF
--- a/frontendshared/src/commonMain/kotlin/de/lehrbaum/initiativetracker/networking/OpenAiNetworkClient.kt
+++ b/frontendshared/src/commonMain/kotlin/de/lehrbaum/initiativetracker/networking/OpenAiNetworkClient.kt
@@ -184,6 +184,6 @@ private val interpretCombatCommandPrompt = """
 
 	{ "target": "", "damage": 0 }
 
-	Jetzt folgt noch eine kommaseparierte Liste aller möglichen Gegner. Das Feld target muss einen dieser Werte 
-	enhalten: 
+        Jetzt folgt noch eine kommaseparierte Liste aller möglichen Gegner. Das Feld target muss einen dieser Werte
+        enthalten:
 """.trimIndent()


### PR DESCRIPTION
## Summary
- correct spelling of `enthalten` in combat command prompt

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884acc96eac8332b1a7208c5616e1d2